### PR TITLE
Hide person modal on mobile

### DIFF
--- a/css/style-team-changes.css
+++ b/css/style-team-changes.css
@@ -15,3 +15,9 @@
 #investors ul {
   justify-content: center !important;
 }
+
+@media screen and (max-width: 1019px) {
+  #person-modal {
+    display: none;
+  }
+}


### PR DESCRIPTION
We used to not display it, mucking w/ the other modals made it start showing up. 1020px is the cutoff where we no longer need the modal since we display the bios inline.